### PR TITLE
add valid input and correct the fhir bundle endpoint path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ TODO: Channel config.
   "status": "completed",
   "authored": "2021-01-20T11:29:52+02:00",
   "author": {
-    "reference": "Practitioner/WhoCrPractitionerExample"
+    "reference": "Practitioner/1844391"
   },
   "item": [
     {
@@ -74,8 +74,8 @@ TODO: Channel config.
           "answer": [
             {
               "valueQuantity": {
-                "value": 34,
-                "code": "a",
+                "value": 11,
+                "code": "d",
                 "system": "http://unitsofmeasure.org"
               }
             }
@@ -118,7 +118,7 @@ TODO: Channel config.
                   "answer": [
                     {
                       "valueCoding": {
-                        "code": "ZA-KZN",
+                        "code": "KZN",
                         "system": "urn:iso:std:iso:3166:-2"
                       }
                     }

--- a/docker/importer/volume/endpoint-bundler.json
+++ b/docker/importer/volume/endpoint-bundler.json
@@ -68,7 +68,7 @@
         "id": "hapi-fhir",
         "config": {
           "method": "post",
-          "url": "http://hapi-fhir:8080/fhir",
+          "url": "http://hapi-fhir:8080/fhir/Bundle",
           "headers": {
             "Content-Type": "application/json"
           }


### PR DESCRIPTION
The input was invalid and the url to send the fhir document bundle was incorrect. It was missing the path "/Bundle", and this was resulting in the error - 'unable to process bundle of type document'

DSC19-54